### PR TITLE
Fix up the heading in the docversion table

### DIFF
--- a/templates/docversions.html
+++ b/templates/docversions.html
@@ -22,25 +22,23 @@
                       <tr>
                         <th></th>
                         <th colspan=3>Man Page</th>
-                        <th colspan=5>User's Guide</th>
-                        <th colspan=3>API</th>
+                        <th colspan=4>User's Guide</th>
+                        <th colspan=2>API</th>
                       </tr>
                       <tr>
                         <th>Version</th>
                         <!--- Man Page -->
                         <th>Single Page HTML</th>
-                        <!-- <th>Post Script</th> -->
+                        <th>PDF</th>
                         <th>Plain Text</th>
                         <!--- Users guide -->
                         <th>Single Page HTML</th>
                         <th>Multi Page HTML</th>
                         <th>PDF</th>
-                        <!-- <th>Post Script</th> -->
                         <th>Plain Text</th>
                         <!--- API -->
                         <th>Multi Page HTML</th>
                         <th>PDF</th>
-                        <!-- <th>Post Script</th> -->
                       </tr>
                     </thead>
                     <tbody>
@@ -49,18 +47,16 @@
                         <td>{{ version }}</td>
                         <!--- Man Page -->
                         <td><a class="btn btn-primary btn-sm" href="{{ SITEURL }}/doc/{{ version }}/HTML/scons-man.html">.html</a></td>
-                        <!-- <td><a class="btn btn-danger btn-sm" href="{{ SITEURL }}/doc/{{ version }}/PS/scons-man.ps">.ps</a></td> -->
+                        <td><a class="btn btn-success btn-sm" href="{{ SITEURL }}/doc/{{ version }}/PDF/scons-man.pdf">.pdf</a></td>
                         <td><a class="btn btn-warning btn-sm" href="{{ SITEURL }}/doc/{{ version }}/TEXT/scons-man.txt">.txt</a></td>
                         <!--- Users guide -->
                         <td><a class="btn btn-primary btn-sm" href="{{ SITEURL }}/doc/{{ version }}/HTML/scons-user.html">.html</a></td>
                         <td><a class="btn btn-info btn-sm" href="{{ SITEURL }}/doc/{{ version }}/HTML/scons-user/index.html">.html</a></td>
                         <td><a class="btn btn-success btn-sm" href="{{ SITEURL }}/doc/{{ version }}/PDF/scons-user.pdf">.pdf</a></td>
-                        <!-- <td><a class="btn btn-danger btn-sm" href="{{ SITEURL }}/doc/{{ version }}/PS/scons-user.ps">.ps</a></td> -->
                         <td><a class="btn btn-warning btn-sm" href="{{ SITEURL }}/doc/{{ version }}/TEXT/scons-user.txt">.txt</a></td>
                         <!--- API -->
                         <td><a class="btn btn-info btn-sm" href="{{ SITEURL }}/doc/{{ version }}/HTML/scons-api/index.html">.html</a></td>
                         <td><a class="btn btn-success btn-sm" href="{{ SITEURL }}/doc/{{ version }}/PDF/scons-api.pdf">.pdf</a></td>
-                        <!-- <td><a class="btn btn-danger btn-sm" href="{{ SITEURL }}/doc/{{ version }}/PS/scons-api.ps">.ps</a></td> -->
                       </tr>
                       {% endfor %}
                     </tbody>


### PR DESCRIPTION
Had gone out of alignment when postscript columns were commented out.

Also adds in manpage PDF

Signed-off-by: Mats Wichmann <mats@linux.com>